### PR TITLE
specify Beacon Biosignals, Inc. as sole copyright holder to make our lawyers happy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Simon Danisch, Beacon Biosignals
+Copyright (c) 2020 Beacon Biosignals, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
...from our open-sourcing policy: "Specify Beacon Biosignals, Inc. as the sole copyright holder."